### PR TITLE
Fix for error when registering and cleaned up error in frontend test file.

### DIFF
--- a/backend/routes/users.js
+++ b/backend/routes/users.js
@@ -97,7 +97,7 @@ router.post('/join', function(req, res) {
       const savedUserJson = savedUser.toJSON();
       delete savedUserJson.hash;
 
-      const token = await TokenService.getToken(user);
+      const token = await TokenService.getToken(savedUserJson);
       return token;
     } catch(err) {
       console.log(err);

--- a/frontend/src/app/pages/lobby-page/lobby-page.component.ts
+++ b/frontend/src/app/pages/lobby-page/lobby-page.component.ts
@@ -1,8 +1,8 @@
 import { Component, OnInit, OnDestroy } from '@angular/core';
 import { ActivatedRoute, Params, Router } from '@angular/router';
 import { environment } from '../../../environments/environment';
-import * as io from 'socket.io-client';
 import { AuthService } from '../../providers';
+import * as io from 'socket.io-client';
 
 @Component({
     selector: 'app-lobby-page',
@@ -29,6 +29,7 @@ export class LobbyPageComponent implements OnInit, OnDestroy {
         this.activatedRoute.params.subscribe((params: Params) => {
             this.roomId = params['roomId'];
             this.authService.getToken().subscribe(token => {
+
                 // Connect to correct socket namespace. (emits connection event)
                 this.socket = io(`${environment.apiUrl}/lobby/room/${this.roomId}`, { query: { token: token} });
                 this.socket.on('connect', () => {
@@ -40,8 +41,10 @@ export class LobbyPageComponent implements OnInit, OnDestroy {
                     console.log('Room updated: ', data);
                     if(data.reason === 'USER_JOINED') {
                         this.numberOfUsers = data.room.usersInRoom.length;
+                        // Display message to users in room informing them of user who joined.
                     } else if(data.reason === 'USER_LEFT') {
                         this.numberOfUsers = data.room.usersInRoom.length;
+                        // Display message to users still in room informing them of user who left.
                     }
                 });
 

--- a/frontend/src/app/providers/auth-service/auth.service.spec.ts
+++ b/frontend/src/app/providers/auth-service/auth.service.spec.ts
@@ -5,11 +5,11 @@ import { AuthService } from './auth.service';
 describe('AuthService', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
-      providers: [AuthServiceService]
+      providers: [AuthService]
     });
   });
 
-  it('should be created', inject([AuthServiceService], (service: AuthService) => {
+  it('should be created', inject([AuthService], (service: AuthService) => {
     expect(service).toBeTruthy();
   }));
 });


### PR DESCRIPTION
Fix for error 'Expected payload to be a plain object' when registering. Looks like the wrong user object was being passed when trying to create a token.