### PR TITLE
Completed Frontend Guests for Lobbys, Additional Canvas Performance Fixes

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -10043,6 +10043,11 @@
         "uuid": "3.2.1"
       }
     },
+    "request-idle-callback": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/request-idle-callback/-/request-idle-callback-1.0.2.tgz",
+      "integrity": "sha1-m7QXcbdGIJ3ovgscPN4hYeQg7dI="
+    },
     "require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -30,6 +30,7 @@
     "jwt-decode": "^2.2.0",
     "ngx-clipboard": "^10.0.0",
     "ngx-color-picker": "^4.5.0",
+    "request-idle-callback": "^1.0.2",
     "rxjs": "^5.5.2",
     "socket.io-client": "^2.0.4",
     "zone.js": "^0.8.14"

--- a/frontend/src/app/components/canvas/canvas.component.ts
+++ b/frontend/src/app/components/canvas/canvas.component.ts
@@ -13,8 +13,12 @@ const CANVAS_UPDATE_EVENT_ID = 'CANVAS_UPDATE';
 })
 export class CanvasComponent implements OnInit, OnChanges, OnDestroy {
 
+
   @Input() socket: any;
+  // User can either be our current user that was logged in (will be assumed on not isReadOnly)
+  // Or, a user to watch for changes to update
   @Input() user: any;
+  @Input() isReadOnly: boolean = false;
 
   authUser: any;
   canvasElementId: string;
@@ -24,7 +28,6 @@ export class CanvasComponent implements OnInit, OnChanges, OnDestroy {
   activeTool: any;
   socketInitialized: boolean = false;
   lcDrawingChangeListener: any;
-  isReadOnly: boolean = false;
   canvasUpdateEvent: any;
 
   constructor(private authService: AuthService) {
@@ -33,16 +36,6 @@ export class CanvasComponent implements OnInit, OnChanges, OnDestroy {
   }
 
   ngOnInit() {
-    // Check if we have a user
-   if(this.user) {
-    // If so, this is a canvas meant for simply listening and rendering events
-    this.isReadOnly = true;
-   }
-
-   // Get the current logged in user
-   this.authService.getUser().subscribe((user) => {
-      this.authUser = user;
-   });
 
    // Initialize our canvas
    this.initializeLiterallyCanvas();
@@ -91,9 +84,9 @@ export class CanvasComponent implements OnInit, OnChanges, OnDestroy {
             const canvasSnapshot = JSON.stringify(this.canvas.getSnapshot());
 
             // Emit to the server, which will then bounce to the approprite users
-            if(this.authUser) {
+            if(this.user) {
               this.socket.emit(CANVAS_UPDATE_EVENT_ID, {
-                user: this.authUser,
+                user: this.user,
                 snapshot: canvasSnapshot
               });
             }
@@ -109,8 +102,9 @@ export class CanvasComponent implements OnInit, OnChanges, OnDestroy {
       this.socketInitialized = true;
 
       // Add the canvas update event
-      if (this.user) {
+      if (this.isReadOnly) {
         this.socket.on(CANVAS_UPDATE_EVENT_ID, (data) => {
+          
           // check if this canvas has a user associated
           if (this.user._id === data.user._id) {
 

--- a/frontend/src/app/components/canvas/canvas.component.ts
+++ b/frontend/src/app/components/canvas/canvas.component.ts
@@ -1,10 +1,8 @@
 import { Component, Input, OnInit, OnChanges, OnDestroy } from '@angular/core';
 import { AuthService } from '../../providers';
 
-// NOTE: if requestAnimationFrame doesn't work out...
-// Need to use: https://www.npmjs.com/package/request-idle-callback
-//declare var require: any;
-//const ric = require('request-idle-callback');
+declare var require: any;
+const ric = require('request-idle-callback');
 
 const CANVAS_UPDATE_EVENT_ID = 'CANVAS_UPDATE';
 
@@ -118,11 +116,11 @@ export class CanvasComponent implements OnInit, OnChanges, OnDestroy {
 
             // Check if we had a pending request
             if (this.canvasUpdateEvent) {
-              cancelAnimationFrame(this.canvasUpdateEvent);
+              ric.cancelIdleCallback(this.canvasUpdateEvent);
             }
 
             // Wrap in a requestIdleCallback
-            this.canvasUpdateEvent = requestAnimationFrame(() => {
+            this.canvasUpdateEvent = ric.requestIdleCallback(() => {
               this.canvasUpdateEvent = false;
               // Get the snapshot, and set it to our canvas
               const snapshot = JSON.parse(data.snapshot);

--- a/frontend/src/app/pages/lobby-page/lobby-page.component.html
+++ b/frontend/src/app/pages/lobby-page/lobby-page.component.html
@@ -20,7 +20,9 @@
                     <app-stream-embed></app-stream-embed>
                 </div>
                 <div class="column is-half">
-                    <app-canvas [socket]="socket"></app-canvas>
+                    <app-canvas [socket]="socket"
+                      [user]="user">
+                    </app-canvas>
                 </div>
             </section>
 
@@ -28,7 +30,10 @@
             <section>
                 <ul class="lobby-canvases">
                     <li *ngFor="let user of getOtherUsersInLobby()">
-                        <app-canvas [socket]="socket" [user]="user.user"></app-canvas>
+                        <app-canvas [socket]="socket"
+                          [user]="user.user"
+                          [isReadOnly]="true">
+                        </app-canvas>
                     </li>
                 </ul>
             </section>

--- a/frontend/src/app/providers/auth-service/auth.service.ts
+++ b/frontend/src/app/providers/auth-service/auth.service.ts
@@ -30,9 +30,11 @@ export class AuthService {
                 token: user.token,
                 user: user.user
             }).subscribe(response => {
-                return observer.next(response);
+                observer.next(response);
+                return observer.complete();
             }, () => {
-                return observer.error('Error storing token');
+                observer.error('Error storing token');
+                return observer.complete();
             });
         });
     }
@@ -44,12 +46,15 @@ export class AuthService {
                 return this.setLoggedInUser(JSON.parse(response._body).token).subscribe(() => {
                     this.userLoggedIn.emit();
                     this.userRegistered.emit();
-                    return observer.next("Successfully created account and logged in");
+                    observer.next("Successfully created account and logged in");
+                    return observer.complete();
                 }, error => {
-                    return observer.error(error);
+                    observer.error(error);
+                    return observer.complete();
                 });
             }, error => {
-                return observer.error(error);
+                observer.error(error);
+                return observer.complete();
             });
         });
     }
@@ -62,12 +67,15 @@ export class AuthService {
                 return this.setLoggedInUser(response).subscribe(() => {
                     this.userLoggedIn.emit();
                     observer.next("Successfully logged in");
-                    return this.router.navigate(['/account']);
+                    this.router.navigate(['/account']);
+                    return observer.complete();
                 }, error => {
-                    return observer.error(error);
+                    observer.error(error);
+                    return observer.complete();
                 });
             }, error => {
-                return observer.error(error);
+                observer.error(error);
+                return observer.complete();
             });
         });
     }
@@ -78,9 +86,11 @@ export class AuthService {
             return this.localStorage.removeItem('brUser').subscribe(() => {
                 this.userLoggedOut.emit();
                 observer.next("Successfully logged out");
-                return this.router.navigate(['/login']);
+                this.router.navigate(['/login']);
+                return observer.complete();
             }, error => {
-                return observer.error(error);
+                observer.error(error);
+                return observer.complete();
             });
         });
     }
@@ -89,9 +99,15 @@ export class AuthService {
     getToken(): Observable<any> {
         return new Observable((observer) => {
             this.localStorage.getItem('brUser').subscribe((response) => {
-                return observer.next(response.token);
+                if(!response || !response.token) {
+                  observer.error('Token was not on brUser localStorage item');
+                  return observer.complete();
+                }
+                observer.next(response.token);
+                return observer.complete();
             }, () => {
-                return observer.error('Could not get token');
+                observer.error('Could not get token');
+                return observer.complete();
             });
         });
     }
@@ -100,9 +116,15 @@ export class AuthService {
     getUser(): Observable<any> {
         return new Observable((observer) => {
             this.localStorage.getItem('brUser').subscribe((response) => {
-                return observer.next(response.user);
+              if(!response || !response.user) {
+                observer.error('User was not on brUser localStorage item');
+                return observer.complete();
+              }
+                observer.next(response.user);
+                return observer.complete();
             }, () => {
-                return observer.error('Could not get token');
+                observer.error('Could not get token');
+                return observer.complete();
             });
         });
     }

--- a/frontend/src/app/providers/lobby-service/lobby.service.ts
+++ b/frontend/src/app/providers/lobby-service/lobby.service.ts
@@ -29,12 +29,15 @@ export class LobbyService {
                 form.token = token;
                 return this.http.post(`${environment.apiUrl}/lobby/create`, form)
                 .map(response => response.json()).subscribe(response => {
-                    return observer.next(response);
+                    observer.next(response);
+                    return observer.complete();
                 }, error => {
-                    return observer.error(error);
+                    observer.error(error);
+                    return observer.complete();
                 });
             }, error => {
-                return observer.error(error);
+                observer.error(error);
+                return observer.complete();
             });
         });
     }


### PR DESCRIPTION
Completed Frontend Guests for lobbys by doing some fadangaling with the token and the user from localstorage. And opted for [`requestIdleCallback()`](https://developers.google.com/web/updates/2015/08/using-requestidlecallback) instead of `requestAnimationFrame()`.

# Example Gif

![paintwithbobguests](https://user-images.githubusercontent.com/1448289/37008576-a0408458-2097-11e8-8650-3999fd62b27c.gif)
