### PR TITLE
Lobby Bleeding, and Incorrect Guest Behavior

### DIFF
--- a/backend/routes/lobby.js
+++ b/backend/routes/lobby.js
@@ -94,7 +94,6 @@ router.get('/guest', function(req, res, next) {
     // If a non-private room is found, send that to the user
     const foundRoom = Object.keys(rooms).some((roomId) => {
         if(!rooms[roomId].isPrivate && rooms[roomId].usersInRoom.length < 4) {
-            console.log('Found a room for a guest!')
             res.status(200).json({
                 roomId: roomId
             });
@@ -105,7 +104,6 @@ router.get('/guest', function(req, res, next) {
 
     // Check if we did not find a room
     if (!foundRoom) {
-        console.log('making a room for a guest!')
         // Kick off our async task
         createLobbyTask(req, res);
     }

--- a/backend/routes/lobby.js
+++ b/backend/routes/lobby.js
@@ -39,7 +39,6 @@ const createLobbyTask = async (req, res, token) => {
         // Define room ID
         // Using JSONParse/stringify for deep clone
         // https://medium.com/@tkssharma/objects-in-javascript-object-assign-deep-copy-64106c9aefab
-        //rooms[roomId] = Object.assign({}, roomObjectSchema);
         rooms[roomId] = JSON.parse(JSON.stringify(roomObjectSchema));
 
         // Set room name

--- a/backend/routes/lobby.js
+++ b/backend/routes/lobby.js
@@ -36,8 +36,11 @@ const createLobbyTask = async (req, res, token) => {
             roomId = (Math.random() * 100).toString(36).substring(7);
         }
 
-        //Define room ID
-        rooms[roomId] = Object.assign({}, roomObjectSchema);
+        // Define room ID
+        // Using JSONParse/stringify for deep clone
+        // https://medium.com/@tkssharma/objects-in-javascript-object-assign-deep-copy-64106c9aefab
+        //rooms[roomId] = Object.assign({}, roomObjectSchema);
+        rooms[roomId] = JSON.parse(JSON.stringify(roomObjectSchema));
 
         // Set room name
         if(req.body.roomName) {
@@ -87,10 +90,12 @@ router.post('/create', function(req, res, next) {
 
 // Lobby Joining and creation for guests
 router.get('/guest', function(req, res, next) {
+
     // Search all rooms for a non-private room
     // If a non-private room is found, send that to the user
     const foundRoom = Object.keys(rooms).some((roomId) => {
-        if(!rooms[roomId].isPrivate) {
+        if(!rooms[roomId].isPrivate && rooms[roomId].usersInRoom.length < 4) {
+            console.log('Found a room for a guest!')
             res.status(200).json({
                 roomId: roomId
             });
@@ -101,6 +106,7 @@ router.get('/guest', function(req, res, next) {
 
     // Check if we did not find a room
     if (!foundRoom) {
+        console.log('making a room for a guest!')
         // Kick off our async task
         createLobbyTask(req, res);
     }


### PR DESCRIPTION
closes #127 

This fixes a weird error where creating multiple lobbys would bleed into one another and things like that. Was because of a deep clone error of the room object schema. Opened 6 different browsers to manually test these cases:

1. Guests could not get placed into private rooms.
2. Guests cannot get placed in rooms with 4 users.
3. Creating a new Lobby won't bleed into another
4. Guests cannot be placed in private rooms

# Screenshot of extreme testing

<img width="1280" alt="screen shot 2018-04-11 at 5 11 42 pm" src="https://user-images.githubusercontent.com/1448289/38649519-fac8c71a-3dab-11e8-8895-6401955033aa.png">
<img width="1280" alt="screen shot 2018-04-11 at 5 12 01 pm" src="https://user-images.githubusercontent.com/1448289/38649520-fdeef0e0-3dab-11e8-91b1-0a58c7a8ec82.png">
